### PR TITLE
Remove standard build setup layout, focus on what's necessary

### DIFF
--- a/basics/setup.md
+++ b/basics/setup.md
@@ -15,21 +15,11 @@ Since ConstaintLayout is part of the [AndroidX libraries](https://developer.andr
 Most likely your project is using other parts of the AndroidX family anyway, but to be sure, here's how to configure your top level `build.gradle` file to use the Google repository:
 
 ```gradle
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.2'
-  }
-}
-
+// ... buildscript, plugins, etc.
 allprojects {
   repositories {
     google()
-    mavenCentral()
+    // ... other repositories, e.g. mavenCentral()
   }
 }
 ```

--- a/basics/setup.md
+++ b/basics/setup.md
@@ -19,7 +19,6 @@ buildscript {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 
   dependencies {
@@ -31,7 +30,6 @@ allprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 }
 ```


### PR DESCRIPTION
mavenCentral() is almost equivalent

https://developer.android.com/studio/build/jcenter-migration